### PR TITLE
Add open source footer to direct messages

### DIFF
--- a/Authors.md
+++ b/Authors.md
@@ -2,3 +2,4 @@
 
 - Spencer Kaiser (spencer.kaiser@aa.com)
 - John Kahn (john.kahn@aa.com)
+- Jeremy Moorman (jeremy.moorman@aa.com)

--- a/src/slack/events/message.ts
+++ b/src/slack/events/message.ts
@@ -2,6 +2,7 @@ import { App } from '@slack/bolt';
 import dashboardBlocks from '../blocks/dashboardBlocks';
 import { Config } from '../../entities/config';
 import logger from '../../logger';
+import openSourceBlock from '../blocks/openSourceFooter';
 
 function register(bolt: App): void {
   bolt.message(async ({ say }) => {
@@ -13,10 +14,10 @@ function register(bolt: App): void {
     try {
       say({
         text: '',
-        blocks: dashboardBlocks(context),
+        blocks: [...dashboardBlocks(context), openSourceBlock],
       });
     } catch (err) {
-      logger.error('Something went messaging the user...', err);
+      logger.error('Something went wrong messaging the user...', err);
     }
   });
 }

--- a/src/slack/events/message.ts
+++ b/src/slack/events/message.ts
@@ -1,8 +1,8 @@
 import { App } from '@slack/bolt';
 import dashboardBlocks from '../blocks/dashboardBlocks';
+import openSourceBlock from '../blocks/openSourceFooter';
 import { Config } from '../../entities/config';
 import logger from '../../logger';
-import openSourceBlock from '../blocks/openSourceFooter';
 
 function register(bolt: App): void {
   bolt.message(async ({ say }) => {


### PR DESCRIPTION
## Pre-Requisites
- [x] Yes, I updated [Authors.md](../Authors.md) **OR** this is not my first contribution
- [x] Yes, I included and/or modified tests to cover relevent code **OR** my change is non-technical
- [x] Yes, I wrote this code entirely myself **OR** I properly attributed these changes in [Third Party Notices](../THIRD-PARTY-NOTICES.txt)

## Description of Changes
<!-- Enter a description of what this PR adds/changes -->
Adds the Open Source Footer block to the bottom of all direct message events.

_Also added missing word in error log for event._ 👀 

![image](https://user-images.githubusercontent.com/5472831/71112117-78910a80-2190-11ea-86a2-bfcdfcc9c353.png)

## Related Issues
<!-- Include a list and brief description of any tracked issues -->
<!-- e.g., "Fixes #123 - A bug that crashes the app" -->
Fixes #40 - Add open source footer to message event response
