### PR TITLE
Added functionality to DM a user when a request is abandoned.

### DIFF
--- a/src/api/supportRequest.ts
+++ b/src/api/supportRequest.ts
@@ -96,9 +96,9 @@ supportRequestRoutes.post('/closeRequest', async (req, res) => {
 });
 
 supportRequestRoutes.post('/abandonRequest', async (req, res) => {
-  const { supportRequestId, timeElapsed } = req.body;
+  const { supportRequestId, relativeTimeElapsedString } = req.body;
 
-  if (!supportRequestId) {
+  if (!supportRequestId || !relativeTimeElapsedString) {
     res.status(400).send("Property 'supportRequestId' is required");
     return;
   }
@@ -118,7 +118,7 @@ supportRequestRoutes.post('/abandonRequest', async (req, res) => {
     supportRequest = await SupportRequest.findOne(supportRequestId);
     await messageUsers(
       [supportRequest.slackId],
-      `:exclamation: We accepted your support request ${timeElapsed}, but we didn't hear from you at our booth, so we closed your request. If you'd still like to meet with our team, please rejoin the queue!`,
+      `:exclamation: We messaged you about your support request ${timeElapsed}, but we didn't hear from you at our booth. Your request has been closed, but if you'd still like to meet with our team, please rejoin the queue!`,
     );
 
     res.sendStatus(200);

--- a/src/api/supportRequest.ts
+++ b/src/api/supportRequest.ts
@@ -118,7 +118,7 @@ supportRequestRoutes.post('/abandonRequest', async (req, res) => {
     supportRequest = await SupportRequest.findOne(supportRequestId);
     await messageUsers(
       [supportRequest.slackId],
-      `:exclamation: We messaged you about your support request ${timeElapsed}, but we didn't hear from you at our booth. Your request has been closed, but if you'd still like to meet with our team, please rejoin the queue!`,
+      `:exclamation: We messaged you about your support request ${relativeTimeElapsedString}, but we didn't hear from you at our booth. Your request has been closed, but if you'd still like to meet with our team, please rejoin the queue!`,
     );
 
     res.sendStatus(200);

--- a/src/api/supportRequest.ts
+++ b/src/api/supportRequest.ts
@@ -86,13 +86,14 @@ supportRequestRoutes.post('/closeRequest', async (req, res) => {
 });
 
 supportRequestRoutes.post('/abandonRequest', async (req, res) => {
-  const { supportRequestId } = req.body;
+  const { supportRequestId, timeElapsed } = req.body;
 
   if (!supportRequestId) {
     res.status(400).send("Property 'supportRequestId' is required");
     return;
   }
 
+  let supportRequest;
   try {
     await SupportRequest.createQueryBuilder('supportRequest')
       .update()
@@ -103,6 +104,12 @@ supportRequestRoutes.post('/abandonRequest', async (req, res) => {
         id: supportRequestId,
       })
       .execute();
+
+    supportRequest = await SupportRequest.findOne(supportRequestId);
+    await messageUsers(
+      [supportRequest.slackId],
+      `:exclamation: We accepted your support request ${timeElapsed}, but we didn't hear from you at our booth, so we closed your request. If you'd still like to meet with our team, please rejoin the queue!`,
+    );
 
     res.sendStatus(200);
   } catch (err) {

--- a/src/api/supportRequest.ts
+++ b/src/api/supportRequest.ts
@@ -103,7 +103,6 @@ supportRequestRoutes.post('/abandonRequest', async (req, res) => {
     return;
   }
 
-  let supportRequest;
   try {
     await SupportRequest.createQueryBuilder('supportRequest')
       .update()
@@ -115,7 +114,7 @@ supportRequestRoutes.post('/abandonRequest', async (req, res) => {
       })
       .execute();
 
-    supportRequest = await SupportRequest.findOne(supportRequestId);
+    const supportRequest = await SupportRequest.findOne(supportRequestId);
     await messageUsers(
       [supportRequest.slackId],
       `:exclamation: We messaged you about your support request ${relativeTimeElapsedString}, but we didn't hear from you at our booth. Your request has been closed, but if you'd still like to meet with our team, please rejoin the queue!`,

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -198,7 +198,7 @@ const AdminPage: NextComponentType = () => {
                         {request.name} <small className="text-muted">{DateTime.fromISO(request.movedToInProgressAt).toRelative()}</small>
                       </h5>
                       <p className="card-text">{request.type === 'TechnicalSupport' ? 'Technical Support' : 'Idea Pitch'}</p>
-                       <button className="btn btn-warning mr-2" onClick={abandonRequest(request.id, request.movedToInProgressAt)}>
+                      <button className="btn btn-warning mr-2" onClick={abandonRequest(request.id, request.movedToInProgressAt)}>
                         No Show
                       </button>
                       <button className="btn btn-success" onClick={closeRequest(request.id)}>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -109,7 +109,7 @@ const AdminPage: NextComponentType = () => {
   };
 
   const abandonRequest = (supportRequestId: number, movedToInProgressAt: string) => async (): Promise<void> => {
-    let timeElapsed = DateTime.fromISO(movedToInProgressAt).toRelative();
+    let relativeTimeElapsedString = DateTime.fromISO(movedToInProgressAt).toRelative();
     await fetch('/api/supportRequest/abandonRequest', {
       method: 'POST',
       body: JSON.stringify({ supportRequestId, relativeTimeElapsedString }),

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -74,10 +74,11 @@ const AdminPage: NextComponentType = () => {
     }
   };
 
-  const abandonRequest = (supportRequestId: number) => async (): Promise<void> => {
+  const abandonRequest = (supportRequestId: number, movedToInProgressAt: string) => async (): Promise<void> => {
+    let timeElapsed = DateTime.fromISO(movedToInProgressAt).toRelative();
     await fetch('/api/supportRequest/abandonRequest', {
       method: 'POST',
-      body: JSON.stringify({ supportRequestId }),
+      body: JSON.stringify({ supportRequestId, timeElapsed }),
       headers: {
         'Content-Type': 'application/json',
       },
@@ -140,7 +141,7 @@ const AdminPage: NextComponentType = () => {
 										<div className="card-body">
 											<h5 className="card-title">{request.name} <small className="text-muted">{DateTime.fromISO(request.movedToInProgressAt).toRelative()}</small></h5>
 											<p className="card-text">{request.type}</p>
-											<button className="btn btn-warning mr-2" onClick={abandonRequest(request.id)}>
+											<button className="btn btn-warning mr-2" onClick={abandonRequest(request.id, request.movedToInProgressAt)}>
 												No Show
 											</button>
 											<button className="btn btn-success" onClick={closeRequest(request.id)}>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -112,7 +112,7 @@ const AdminPage: NextComponentType = () => {
     let timeElapsed = DateTime.fromISO(movedToInProgressAt).toRelative();
     await fetch('/api/supportRequest/abandonRequest', {
       method: 'POST',
-      body: JSON.stringify({ supportRequestId, timeElapsed }),
+      body: JSON.stringify({ supportRequestId, relativeTimeElapsedString }),
       headers: {
         'Content-Type': 'application/json',
       },

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -198,7 +198,7 @@ const AdminPage: NextComponentType = () => {
                         {request.name} <small className="text-muted">{DateTime.fromISO(request.movedToInProgressAt).toRelative()}</small>
                       </h5>
                       <p className="card-text">{request.type === 'TechnicalSupport' ? 'Technical Support' : 'Idea Pitch'}</p>
-                      <button className="btn btn-warning mr-2" onClick={abandonRequest(request.id, request.movedToInProgressAt)}>
+                      <button className="btn btn-danger mr-2" onClick={abandonRequest(request.id, request.movedToInProgressAt)}>
                         No Show
                       </button>
                       <button className="btn btn-success" onClick={closeRequest(request.id)}>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -198,7 +198,7 @@ const AdminPage: NextComponentType = () => {
                         {request.name} <small className="text-muted">{DateTime.fromISO(request.movedToInProgressAt).toRelative()}</small>
                       </h5>
                       <p className="card-text">{request.type === 'TechnicalSupport' ? 'Technical Support' : 'Idea Pitch'}</p>
-											<button className="btn btn-warning mr-2" onClick={abandonRequest(request.id, request.movedToInProgressAt)}>
+                       <button className="btn btn-warning mr-2" onClick={abandonRequest(request.id, request.movedToInProgressAt)}>
                         No Show
                       </button>
                       <button className="btn btn-success" onClick={closeRequest(request.id)}>

--- a/src/tests/api/supportRequest.test.ts
+++ b/src/tests/api/supportRequest.test.ts
@@ -126,7 +126,7 @@ describe('api/judging', () => {
     const { app } = require('../../app');
     await supertest(app)
       .post('/api/supportRequest/abandonRequest')
-      .send({ supportRequestId: supportRequest.id, timeElapsed: '' })
+      .send({ supportRequestId: supportRequest.id, relativeTimeElapsedString: '' })
       .set({
         Authorization: adminSecret,
         'Content-Type': 'application/json',

--- a/src/tests/api/supportRequest.test.ts
+++ b/src/tests/api/supportRequest.test.ts
@@ -110,7 +110,7 @@ describe('api/judging', () => {
     const { app } = require('../../app');
     await supertest(app)
       .post('/api/supportRequest/abandonRequest')
-      .send({ relativeTimeElapsedString: "some time ago" })
+      .send({ relativeTimeElapsedString: 'some time ago' })
       .set({
         Authorization: adminSecret,
         'Content-Type': 'application/json',
@@ -143,7 +143,7 @@ describe('api/judging', () => {
     const { app } = require('../../app');
     await supertest(app)
       .post('/api/supportRequest/abandonRequest')
-      .send({ supportRequestId: supportRequest.id, relativeTimeElapsedString: "some time ago" })
+      .send({ supportRequestId: supportRequest.id, relativeTimeElapsedString: 'some time ago' })
       .set({
         Authorization: adminSecret,
         'Content-Type': 'application/json',

--- a/src/tests/api/supportRequest.test.ts
+++ b/src/tests/api/supportRequest.test.ts
@@ -110,6 +110,23 @@ describe('api/judging', () => {
     const { app } = require('../../app');
     await supertest(app)
       .post('/api/supportRequest/abandonRequest')
+      .send({ relativeTimeElapsedString: "some time ago" })
+      .set({
+        Authorization: adminSecret,
+        'Content-Type': 'application/json',
+      })
+      .expect(400);
+  });
+
+  it('calling abandonRequest without relativeTimeElapsedString will be a 400', async () => {
+    const suppportRequest = new SupportRequest('slackId', 'name', SupportRequestType.IdeaPitch);
+    suppportRequest.status = SupportRequestStatus.InProgress;
+    await suppportRequest.save();
+
+    const { app } = require('../../app');
+    await supertest(app)
+      .post('/api/supportRequest/abandonRequest')
+      .send({ supportRequestId: 1 })
       .set({
         Authorization: adminSecret,
         'Content-Type': 'application/json',
@@ -126,7 +143,7 @@ describe('api/judging', () => {
     const { app } = require('../../app');
     await supertest(app)
       .post('/api/supportRequest/abandonRequest')
-      .send({ supportRequestId: supportRequest.id, relativeTimeElapsedString: '' })
+      .send({ supportRequestId: supportRequest.id, relativeTimeElapsedString: "some time ago" })
       .set({
         Authorization: adminSecret,
         'Content-Type': 'application/json',

--- a/src/tests/api/supportRequest.test.ts
+++ b/src/tests/api/supportRequest.test.ts
@@ -1,7 +1,9 @@
 import 'jest';
+jest.mock('../../slack/utilities/messageUsers');
 import supertest from 'supertest';
 import { SupportRequest, SupportRequestType, SupportRequestStatus } from '../../entities/supportRequest';
 import { createDbConnection, closeDbConnection } from '../testdb';
+import '../../slack/utilities/messageUsers';
 
 const adminSecret = 'Secrets are secretive';
 
@@ -119,10 +121,11 @@ describe('api/judging', () => {
     supportRequest.status = SupportRequestStatus.InProgress;
     await supportRequest.save();
 
+    jest.mock('../../slack/utilities/messageUsers');
     const { app } = require('../../app');
     await supertest(app)
       .post('/api/supportRequest/abandonRequest')
-      .send({ supportRequestId: supportRequest.id })
+      .send({ supportRequestId: supportRequest.id, timeElapsed: '' })
       .set({
         Authorization: adminSecret,
         'Content-Type': 'application/json',


### PR DESCRIPTION
## Pre-Requisites
- [x] Yes, I updated [Authors.md](../Authors.md) **OR** this is not my first contribution
- [x] Yes, I included and/or modified tests to cover relevent code **OR** my change is non-technical
- [x] Yes, I wrote this code entirely myself **OR** I properly attributed these changes in [Third Party Notices](../THIRD-PARTY-NOTICES.txt)

## Description of Changes
<!-- Enter a description of what this PR adds/changes -->
- When a user's support request is abandoned via the UI, a DM is sent to that user stating their request was closed.

Screenshot:
<img width="968" alt="Screen Shot 2020-01-26 at 9 48 01 AM" src="https://user-images.githubusercontent.com/5331378/73137726-fe6e6400-4020-11ea-9259-66b0276e3d3f.png">

## Related Issues
<!-- Include a list and brief description of any tracked issues -->
<!-- e.g., "Fixes #123 - A bug that crashes the app" -->
- Fixes #103 