### PR TITLE
Feature/judge step away resume

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -3,11 +3,11 @@ import express from 'express';
 import { requireAuth } from './middleware/requireAuth';
 import { supportRequestRoutes } from './supportRequest';
 import { Judge } from '../entities/judge';
-import { Team } from '../entities/team';
 import { sendUpdateMessage } from './sendUpdateMessage';
 import { judging } from './judging';
 import { config } from './config';
 import { admin } from './admin';
+import { judgeActions } from './judge';
 
 const api = express();
 
@@ -23,63 +23,7 @@ api.post('/judge', async (_req, res) => {
   res.send(judge.id.toString());
 });
 
-const getJudgeTeams = async (judge: Judge): Promise<{ currentTeam: Team; previousTeam: Team }> => {
-  const previousTeamId = judge.previousTeam;
-
-  let currentTeam;
-  if (judge.currentTeam) {
-    currentTeam = await Team.findOne(judge.currentTeam);
-  } else {
-    currentTeam = ((await judge.getNextTeam()) as unknown) as Team;
-  }
-
-  let previousTeam;
-  if (previousTeamId) {
-    previousTeam = await Team.findOne(previousTeamId);
-  }
-
-  return {
-    currentTeam,
-    previousTeam,
-  };
-};
-
-api.get('/judge/teams', async (req, res) => {
-  const judge = await Judge.findOneOrFail(parseInt(req.query.id, 10));
-
-  res.send(await getJudgeTeams(judge));
-});
-
-api.post('/vote', async (req, res) => {
-  if (!req.body.id) {
-    res.sendStatus(500).send('Whoops');
-    return;
-  }
-
-  const judge = await Judge.findOne(req.body.id);
-
-  if (req.body.currentTeamChosen === null || req.body.currentTeamChosen === undefined) {
-    await judge.continue();
-  } else {
-    await judge.vote(req.body.currentTeamChosen);
-  }
-
-  res.send(await getJudgeTeams(judge));
-});
-
-api.post('/skip', async (req, res) => {
-  if (!req.body.id) {
-    res.sendStatus(400).send('No id');
-    return;
-  }
-
-  const judge = await Judge.findOne(req.body.id);
-
-  await judge.skip();
-
-  res.send(await getJudgeTeams(judge));
-});
-
+api.use(judgeActions);
 api.use('/sendUpdateMessage', requireAuth(), sendUpdateMessage);
 api.use('/supportRequest', requireAuth(), supportRequestRoutes);
 api.use('/judging', requireAuth(), judging);

--- a/src/api/judge.ts
+++ b/src/api/judge.ts
@@ -1,0 +1,99 @@
+import express from 'express';
+import { Judge } from '../entities/judge';
+import { Team } from '../entities/team';
+
+interface JudgeTeams {
+  currentTeam: Team;
+  previousTeam: Team;
+}
+
+export const judgeActions = express.Router();
+
+const getJudgeTeams = async (judge: Judge): Promise<JudgeTeams> => {
+  const previousTeamId = judge.previousTeam;
+
+  let currentTeam;
+  if (judge.currentTeam) {
+    currentTeam = await Team.findOne(judge.currentTeam);
+  } else {
+    currentTeam = ((await judge.getNextTeam()) as unknown) as Team;
+  }
+
+  let previousTeam;
+  if (previousTeamId) {
+    previousTeam = await Team.findOne(previousTeamId);
+  }
+
+  return {
+    currentTeam,
+    previousTeam,
+  };
+};
+
+judgeActions.get('/judge/teams', async (req, res) => {
+  const judge = await Judge.findOneOrFail(parseInt(req.query.id, 10));
+
+  res.send(await getJudgeTeams(judge));
+});
+
+judgeActions.post('/vote', async (req, res) => {
+  if (!req.body.id) {
+    res.sendStatus(500).send('Whoops');
+    return;
+  }
+
+  const judge = await Judge.findOne(req.body.id);
+
+  if (req.body.currentTeamChosen === null || req.body.currentTeamChosen === undefined) {
+    await judge.continue();
+  } else {
+    await judge.vote(req.body.currentTeamChosen);
+  }
+
+  res.send(await getJudgeTeams(judge));
+});
+
+judgeActions.post('/skip', async (req, res) => {
+  if (!req.body.id) {
+    res.sendStatus(400).send('No id');
+    return;
+  }
+
+  const judge = await Judge.findOne(req.body.id);
+
+  await judge.skip();
+
+  res.send(await getJudgeTeams(judge));
+});
+
+judgeActions.post('/break', async (req, res) => {
+  if (!req.body.id) {
+    res.sendStatus(400).send('No id');
+    return;
+  }
+
+  const judge = await Judge.findOne(req.body.id);
+
+  if (judge) {
+    await judge.stepAway();
+  }
+
+  res.send({ success: judge?.away ?? false });
+});
+
+judgeActions.post('/resume', async (req, res) => {
+  if (!req.body.id) {
+    res.sendStatus(400).send('No id');
+    return;
+  }
+
+  const judge = await Judge.findOne(req.body.id);
+  let judgeTeams: JudgeTeams;
+
+  if (judge) {
+    await judge.resumeJudging();
+    judgeTeams = await getJudgeTeams(judge);
+  }
+
+  res.send(judgeTeams);
+});

--- a/src/api/judge.ts
+++ b/src/api/judge.ts
@@ -3,6 +3,7 @@ import { Judge } from '../entities/judge';
 import { Team } from '../entities/team';
 
 interface JudgeTeams {
+  away: boolean;
   currentTeam: Team;
   previousTeam: Team;
 }
@@ -25,6 +26,7 @@ const getJudgeTeams = async (judge: Judge): Promise<JudgeTeams> => {
   }
 
   return {
+    away: judge.away,
     currentTeam,
     previousTeam,
   };

--- a/src/entities/judge.ts
+++ b/src/entities/judge.ts
@@ -58,7 +58,7 @@ export class Judge extends BaseEntity {
     }
 
     const team = await Team.findOne({ id: this.currentTeam });
-    this.away = true;
+    this.away = false;
 
     if (team) {
       await team.incrementActiveJudgeCount();

--- a/src/entities/judge.ts
+++ b/src/entities/judge.ts
@@ -38,9 +38,9 @@ export class Judge extends BaseEntity {
     await this.recordCurrentTeamAndSave();
   }
 
-  async stepAway(): Promise<Judge> {
+  async stepAway(): Promise<void> {
     if (this.away) {
-      return this;
+      return;
     }
 
     const team = await Team.findOne({ id: this.currentTeam });
@@ -50,8 +50,21 @@ export class Judge extends BaseEntity {
       await team.decrementActiveJudgeCount();
       await this.save();
     }
+  }
 
-    return this;
+  async resumeJudging(): Promise<void> {
+    if (!this.away) {
+      return;
+    }
+
+    const team = await Team.findOne({ id: this.currentTeam });
+    this.away = true;
+
+    if (team) {
+      await team.incrementActiveJudgeCount();
+    }
+
+    await this.save();
   }
 
   async skip(): Promise<void> {

--- a/src/entities/judge.ts
+++ b/src/entities/judge.ts
@@ -39,6 +39,10 @@ export class Judge extends BaseEntity {
   }
 
   async stepAway(): Promise<Judge> {
+    if (this.away) {
+      return this;
+    }
+
     const team = await Team.findOne({ id: this.currentTeam });
 
     if (team?.activeJudgeCount > 0) {

--- a/src/entities/judge.ts
+++ b/src/entities/judge.ts
@@ -38,17 +38,16 @@ export class Judge extends BaseEntity {
     await this.recordCurrentTeamAndSave();
   }
 
-  async stepAway(): Promise<boolean> {
+  async stepAway(): Promise<Judge> {
     const team = await Team.findOne({ id: this.currentTeam });
 
     if (team?.activeJudgeCount > 0) {
       this.away = true;
       await team.decrementActiveJudgeCount();
       await this.save();
-      return true;
     }
 
-    return false;
+    return this;
   }
 
   async skip(): Promise<void> {

--- a/src/entities/team.ts
+++ b/src/entities/team.ts
@@ -108,6 +108,11 @@ export class Team extends BaseEntity {
       .execute();
   }
 
+  async incrementActiveJudgeCount(): Promise<Team> {
+    this.activeJudgeCount = this.activeJudgeCount + 1;
+    return this.save();
+  }
+
   async incrementJudgeVisits(): Promise<void> {
     await Team.createQueryBuilder('team')
       .update()

--- a/src/migration/1582338396319-AddAwayBooleanToJudge.ts
+++ b/src/migration/1582338396319-AddAwayBooleanToJudge.ts
@@ -1,0 +1,11 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddAwayBooleanToJudge1582338396319 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<any> {
+    await queryRunner.query('ALTER TABLE "judge" ADD "away" boolean NOT NULL', undefined);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<any> {
+    await queryRunner.query('ALTER TABLE "judge" DROP COLUMN "away"', undefined);
+  }
+}

--- a/src/tests/entities/judge.test.ts
+++ b/src/tests/entities/judge.test.ts
@@ -89,6 +89,12 @@ describe('judge entity', () => {
       await judge.save();
     });
 
+    it('sets the judge as present', async () => {
+      await judge.resumeJudging();
+
+      expect(judge.away).toBe(false);
+    });
+
     it('increases the active judge count by one', async () => {
       await judge.resumeJudging();
 

--- a/src/tests/entities/judge.test.ts
+++ b/src/tests/entities/judge.test.ts
@@ -20,14 +20,14 @@ describe('judge entity', () => {
       team = await new Team('Some Team', 123, 'A new app', ['123']);
       team.activeJudgeCount = 1;
       await team.save();
-      
+
       judge = await new Judge();
       judge.currentTeam = team.id;
       await judge.save();
     });
 
     it('should set the judge to away', async () => {
-      judge = await judge.stepAway();
+      await judge.stepAway();
 
       expect(judge.away).toBe(true);
     });
@@ -60,7 +60,7 @@ describe('judge entity', () => {
       });
 
       it('should not set the judge to away', async () => {
-        judge = await judge.stepAway();
+        await judge.stepAway();
 
         expect(judge.away).toBe(false);
       });
@@ -82,7 +82,7 @@ describe('judge entity', () => {
       team = await new Team('Some Team', 123, 'A new app', ['123']);
       team.activeJudgeCount = 1;
       await team.save();
-      
+
       judge = await new Judge();
       judge.currentTeam = team.id;
       judge.away = true;

--- a/src/tests/entities/judge.test.ts
+++ b/src/tests/entities/judge.test.ts
@@ -20,14 +20,14 @@ describe('judge entity', () => {
       judge = await new Judge();
       team = await new Team('Some Team', 123, 'A new app', ['123']);
 
-      judge = await judge.save();
-      team = await team.save();
+      await judge.save();
+      await team.save();
 
       judge.currentTeam = team.id;
       team.activeJudgeCount = 1;
 
-      judge = await judge.save();
-      team = await team.save();
+      await judge.save();
+      await team.save();
     });
 
     it('should set the judge to away', async () => {
@@ -42,6 +42,19 @@ describe('judge entity', () => {
       await team.reload();
 
       expect(team.activeJudgeCount).toBe(0);
+    });
+
+    describe('when judge is already away', () => {
+      beforeEach(async () => {
+        judge.away = true;
+        await judge.save();
+      });
+
+      it('will not reduce the active judge count of team', async () => {
+        await judge.stepAway();
+        await team.reload();
+        expect(team.activeJudgeCount).toBe(1);
+      });
     });
 
     describe('when active judge count of team has less than 1', () => {

--- a/src/tests/entities/judge.test.ts
+++ b/src/tests/entities/judge.test.ts
@@ -30,14 +30,8 @@ describe('judge entity', () => {
       team = await team.save();
     });
 
-    it('return true', async () => {
-      const successfulStepAway = await judge.stepAway();
-
-      expect(successfulStepAway).toBe(true);
-    });
-
     it('should set the judge to away', async () => {
-      await judge.stepAway();
+      judge = await judge.stepAway();
 
       expect(judge.away).toBe(true);
     });
@@ -56,14 +50,8 @@ describe('judge entity', () => {
         await team.save();
       });
 
-      it('return false', async () => {
-        const unsuccessfulStepAway = await judge.stepAway();
-
-        expect(unsuccessfulStepAway).toBe(false);
-      });
-
       it('should not set the judge to away', async () => {
-        await judge.stepAway();
+        judge = await judge.stepAway();
 
         expect(judge.away).toBe(false);
       });

--- a/src/tests/entities/judge.test.ts
+++ b/src/tests/entities/judge.test.ts
@@ -14,10 +14,11 @@ describe('judge entity', () => {
 
   describe('stepAway()', () => {
     let judge: Judge;
+    let team: Team;
 
     beforeEach(async () => {
       judge = await new Judge();
-      let team = await new Team('Some Team', 123, 'A new app', ['123']);
+      team = await new Team('Some Team', 123, 'A new app', ['123']);
 
       judge = await judge.save();
       team = await team.save();
@@ -44,14 +45,13 @@ describe('judge entity', () => {
     it('should reduce the active judge count for the team', async () => {
       await judge.stepAway();
 
-      const team = await Team.findOne({ id: judge.currentTeam });
+      await team.reload();
 
       expect(team.activeJudgeCount).toBe(0);
     });
 
     describe('when active judge count of team has less than 1', () => {
       beforeEach(async () => {
-        const team = await Team.findOne({ id: judge.currentTeam });
         team.activeJudgeCount = 0;
         await team.save();
       });
@@ -71,7 +71,7 @@ describe('judge entity', () => {
       it('should not reduce the active judge count of team', async () => {
         await judge.stepAway();
 
-        const team = await Team.findOne({ id: judge.currentTeam });
+        await team.reload();
         expect(team.activeJudgeCount).toBe(0);
       });
     });

--- a/src/tests/entities/judge.test.ts
+++ b/src/tests/entities/judge.test.ts
@@ -17,17 +17,13 @@ describe('judge entity', () => {
     let team: Team;
 
     beforeEach(async () => {
-      judge = await new Judge();
       team = await new Team('Some Team', 123, 'A new app', ['123']);
-
-      await judge.save();
-      await team.save();
-
-      judge.currentTeam = team.id;
       team.activeJudgeCount = 1;
-
-      await judge.save();
       await team.save();
+      
+      judge = await new Judge();
+      judge.currentTeam = team.id;
+      await judge.save();
     });
 
     it('should set the judge to away', async () => {
@@ -75,6 +71,38 @@ describe('judge entity', () => {
         await team.reload();
         expect(team.activeJudgeCount).toBe(0);
       });
+    });
+  });
+
+  describe('resumeJudging()', () => {
+    let judge: Judge;
+    let team: Team;
+
+    beforeEach(async () => {
+      team = await new Team('Some Team', 123, 'A new app', ['123']);
+      team.activeJudgeCount = 1;
+      await team.save();
+      
+      judge = await new Judge();
+      judge.currentTeam = team.id;
+      judge.away = true;
+      await judge.save();
+    });
+
+    it('increases the active judge count by one', async () => {
+      await judge.resumeJudging();
+
+      await team.reload();
+      expect(team.activeJudgeCount).toBe(2);
+    });
+
+    it('does not increase the active judge count when not away', async () => {
+      judge.away = false;
+      await judge.save();
+      await judge.resumeJudging();
+
+      await team.reload();
+      expect(team.activeJudgeCount).toBe(1);
     });
   });
 });

--- a/src/tests/entities/judge.test.ts
+++ b/src/tests/entities/judge.test.ts
@@ -1,0 +1,79 @@
+import 'jest';
+import { createDbConnection, closeDbConnection } from '../testdb';
+import { Judge } from '../../entities/judge';
+import { Team } from '../../entities/team';
+
+describe('judge entity', () => {
+  beforeEach(async () => {
+    await createDbConnection();
+  });
+
+  afterEach(async () => {
+    await closeDbConnection();
+  });
+
+  describe('stepAway()', () => {
+    let judge: Judge;
+
+    beforeEach(async () => {
+      judge = await new Judge();
+      let team = await new Team('Some Team', 123, 'A new app', ['123']);
+
+      judge = await judge.save();
+      team = await team.save();
+
+      judge.currentTeam = team.id;
+      team.activeJudgeCount = 1;
+
+      judge = await judge.save();
+      team = await team.save();
+    });
+
+    it('return true', async () => {
+      const successfulStepAway = await judge.stepAway();
+
+      expect(successfulStepAway).toBe(true);
+    });
+
+    it('should set the judge to away', async () => {
+      await judge.stepAway();
+
+      expect(judge.away).toBe(true);
+    });
+
+    it('should reduce the active judge count for the team', async () => {
+      await judge.stepAway();
+
+      const team = await Team.findOne({ id: judge.currentTeam });
+
+      expect(team.activeJudgeCount).toBe(0);
+    });
+
+    describe('when active judge count of team has less than 1', () => {
+      beforeEach(async () => {
+        const team = await Team.findOne({ id: judge.currentTeam });
+        team.activeJudgeCount = 0;
+        await team.save();
+      });
+
+      it('return false', async () => {
+        const unsuccessfulStepAway = await judge.stepAway();
+
+        expect(unsuccessfulStepAway).toBe(false);
+      });
+
+      it('should not set the judge to away', async () => {
+        await judge.stepAway();
+
+        expect(judge.away).toBe(false);
+      });
+
+      it('should not reduce the active judge count of team', async () => {
+        await judge.stepAway();
+
+        const team = await Team.findOne({ id: judge.currentTeam });
+        expect(team.activeJudgeCount).toBe(0);
+      });
+    });
+  });
+});

--- a/src/tests/entities/team.test.ts
+++ b/src/tests/entities/team.test.ts
@@ -71,4 +71,12 @@ describe('judging', () => {
     expect(newTeam).toBeUndefined();
     expect(mockMethod.mock.calls.length).toBe(5);
   });
+
+  describe('incrementActiveJudgeCount()', () => {
+    it('increases the active judge count by 1', async () => {
+      const oldCount = team.activeJudgeCount;
+      team = await team.incrementActiveJudgeCount();
+      expect(team.activeJudgeCount).toBe(oldCount + 1);
+    });
+  });
 });


### PR DESCRIPTION
## Pre-Requisites
- [x] Yes, I updated [Authors.md](../Authors.md) **OR** this is not my first contribution
- [x] Yes, I included and/or modified tests to cover relevent code **OR** my change is non-technical
- [x] Yes, I wrote this code entirely myself **OR** I properly attributed these changes in [Third Party Notices](../THIRD-PARTY-NOTICES.txt)

## Description of Changes
Adds the ability for a judge to take a break.

- If the judge's current team has less than 1 active judge, the judge will not be set to away or shown the break screen.
- If break request is successful, reduces the active judge count for the current team by 1
- Resuming judging increases the current teams active judge count by 1 and syncs the current/previous team for the UI
- Judges away status persists through reload.

_Refactorings:_

- Took many of the judge functions from _api/index.ts_ and moved them into their own file (_api/judge.ts_).

_Possible Improvements:_

- Increase code coverage of new routes.
- Remove all logic out of _api/_ and use exclusively for routing to make testing logic easier and follow better SOLID principles.
- Make break view less "MVP"

**Break Button:**

<img width="1680" alt="image" src="https://user-images.githubusercontent.com/5472831/75097636-b9cbdf00-5572-11ea-8026-b0a606622c2a.png">

**Break Screen and Resume Button:**

<img width="1680" alt="image" src="https://user-images.githubusercontent.com/5472831/75097662-f7c90300-5572-11ea-99f0-dee1b983c26b.png">

## Related Issues
Fixes #111 - Give judges the option to stop/take a break
