### PR TITLE
Fixing the team registration error to use a modal

### DIFF
--- a/src/slack/actions/registerTeam.ts
+++ b/src/slack/actions/registerTeam.ts
@@ -2,8 +2,8 @@ import { Middleware, SlackActionMiddlewareArgs, BlockButtonAction } from '@slack
 import { app } from '..';
 import { registerTeamView } from '../blocks/registerTeam';
 import logger from '../../logger';
-import { DmOpenResult } from '../types';
 import { Config } from '../../entities/config';
+import { openAlertModal } from '../utilities/openAlertModal';
 
 // Ignore snake_case types from @slack/bolt
 /* eslint-disable @typescript-eslint/camelcase, @typescript-eslint/no-explicit-any */
@@ -13,15 +13,10 @@ export const registerTeam: Middleware<SlackActionMiddlewareArgs<BlockButtonActio
   try {
     const teamRegistrationActive = await Config.findToggleForKey('teamRegistrationActive');
     if (!teamRegistrationActive) {
-      const dm = (await app.client.conversations.open({
-        token: context.botToken,
-        users: body.user.id,
-      })) as DmOpenResult;
-
-      await app.client.chat.postMessage({
-        token: context.botToken,
-        channel: dm.channel.id,
-        text: ':warning: Team registration is not open yet. Check back later once table numbers have been assigned!',
+      await openAlertModal(context.botToken, body.trigger_id, {
+        title: 'Registration Not Open',
+        text:
+          ":warning: Team registration is not open yet. Check back later or, if you're subscribed to updates, watch for a direct message from the bot!",
       });
       return;
     }

--- a/src/slack/blocks/dashboardBlocks.ts
+++ b/src/slack/blocks/dashboardBlocks.ts
@@ -121,7 +121,7 @@ const teamRegistrationBlock: KnownBlock = {
     type: 'button',
     text: {
       type: 'plain_text',
-      text: 'Register',
+      text: 'Register Team',
     },
     action_id: actionIds.registerTeam,
   },


### PR DESCRIPTION
## Pre-Requisites
- [x] Yes, I updated [Authors.md](../blob/main/Authors.md) **OR** this is not my first contribution
- [ ] Yes, I included and/or modified tests to cover relevent code **OR** my change is non-technical
- [x] Yes, I wrote this code entirely myself **OR** I properly attributed these changes in [Third Party Notices](../blob/main/THIRD-PARTY-NOTICES.txt)

<!-- After addressing the pre-requisites above, make sure to fill out BOTH sections below -->
<!-- NOTE: This is a comment; the comments below will be hidden when you submit -->

## Description of Changes
<!-- Enter a description of what this PR adds/changes -->
- Fixing a missed error DM and replacing it with a modal
- Updating Team registration button to have more appropriate verbiage

## Related Issues
<!-- Include a list and brief description of any tracked issues -->
<!-- NOTE: Make sure to use the `Closes`/`Fixes` syntax to automatically close the issue when your PR is merged -->
<!-- More detail: https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords -->
<!-- e.g., "Closes #123 - A bug that crashes the app" -->
