### PR TITLE
Add stopwatch to judge screen

### DIFF
--- a/src/pages/judge/[secret].tsx
+++ b/src/pages/judge/[secret].tsx
@@ -174,6 +174,14 @@ const judge = (): JSX.Element => {
 
   return (
     <div className="container-fluid text-center">
+    <body>
+      <h1 id="timer">00 : 00 . 000</h1>
+        <div>
+          <button id="toggle">Start</button>
+          <button id="reset">Reset</button>
+        </div>
+    </body>
+    
       <h1>Welcome Judge!</h1>
       {error && <p style={{ color: 'red' }}>{error}, refresh and try again</p>}
       {currentTeam && (


### PR DESCRIPTION
## Pre-Requisites
- [x] Yes, I updated [Authors.md](../blob/main/Authors.md) **OR** this is not my first contribution
- [x] Yes, I included and/or modified tests to cover relevent code **OR** my change is non-technical
- [x] Yes, I wrote this code entirely myself **OR** I properly attributed these changes in [Third Party Notices](../blob/main/THIRD-PARTY-NOTICES.txt)

<!-- After addressing the pre-requisites above, make sure to fill out BOTH sections below -->
<!-- NOTE: This is a comment; the comments below will be hidden when you submit -->

## Description of Changes
<!-- Enter a description of what this PR adds/changes -->
Added stopwatch to judge screen

Worked with @oscargoddard 

This is how it looks on the judging screen

<img width="1434" alt="Screen Shot 2020-10-22 at 7 36 50 PM" src="https://user-images.githubusercontent.com/39110243/96943507-f9e6b700-149d-11eb-8ade-9f27e6c4021d.png">

## Related Issues
<!-- Include a list and brief description of any tracked issues -->
<!-- NOTE: Make sure to use the `Closes`/`Fixes` syntax to automatically close the issue when your PR is merged -->
<!-- More detail: https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords -->
<!-- e.g., "Closes #123 - A bug that crashes the app" -->
Closes #108 
