### PR TITLE
Deprecating testdb

### DIFF
--- a/src/tests/testdb.ts
+++ b/src/tests/testdb.ts
@@ -3,6 +3,9 @@ import path from 'path';
 import { SqliteConnectionOptions } from 'typeorm/driver/sqlite/SqliteConnectionOptions';
 // import { PostgresConnectionOptions } from 'typeorm/driver/postgres/PostgresConnectionOptions';
 
+/**
+ * @deprecated New tests should not use the in-memory database; instead they should mock necessary files/implementations
+ */
 export async function createDbConnection(): Promise<void> {
   await createConnection({
     type: 'sqlite',
@@ -22,6 +25,9 @@ export async function createDbConnection(): Promise<void> {
   // } as PostgresConnectionOptions);
 }
 
+/**
+ * @deprecated New tests should not use the in-memory database; instead they should mock necessary files/implementations
+ */
 export async function closeDbConnection(): Promise<void> {
   await getConnection().close();
 }


### PR DESCRIPTION
## Pre-Requisites
- [x] Yes, I updated [Authors.md](../blob/main/Authors.md) **OR** this is not my first contribution
- [x] Yes, I included and/or modified tests to cover relevent code **OR** my change is non-technical
- [x] Yes, I wrote this code entirely myself **OR** I properly attributed these changes in [Third Party Notices](../blob/main/THIRD-PARTY-NOTICES.txt)

<!-- After addressing the pre-requisites above, make sure to fill out BOTH sections below -->
<!-- NOTE: This is a comment; the comments below will be hidden when you submit -->

## Description of Changes
<!-- Enter a description of what this PR adds/changes -->
Marking our in-memory test db utils as being deprecated to prevent new tests from using them

## Related Issues
<!-- Include a list and brief description of any tracked issues -->
<!-- NOTE: Make sure to use the `Closes`/`Fixes` syntax to automatically close the issue when your PR is merged -->
<!-- More detail: https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords -->
<!-- e.g., "Closes #123 - A bug that crashes the app" -->
