### PR TITLE
Fixing a bug where getting the next team would fail for new judges

### DIFF
--- a/src/entities/team.ts
+++ b/src/entities/team.ts
@@ -55,9 +55,7 @@ export class Team extends BaseEntity {
     /* eslint-disable no-await-in-loop */
     do {
       team = await Team.findOne({
-        where: {
-          id: Not(In(excludedTeamIds)),
-        },
+        where: excludedTeamIds.length ? { id: Not(In(excludedTeamIds)) } : {},
         order: {
           activeJudgeCount: 'ASC',
           judgeVisits: 'ASC',

--- a/src/tests/entities/team.test.ts
+++ b/src/tests/entities/team.test.ts
@@ -47,7 +47,7 @@ describe('getNextAvailableTeamExcludingTeams util method', () => {
     expect(updateSelectedTeamSpy).toBeCalledTimes(1);
     const findOneOptions = findOneSpy.mock.calls[0][0] as FindOneOptions<Team>;
     // eslint-disable-next-line no-underscore-dangle
-    expect((findOneOptions.where as any).id._value._value).toEqual([]);
+    expect(findOneOptions.where).toEqual({});
     expect(nextTeam.id).toEqual(mockTeam.id);
   });
 


### PR DESCRIPTION
## Pre-Requisites
- [x] Yes, I updated [Authors.md](../blob/main/Authors.md) **OR** this is not my first contribution
- [x] Yes, I included and/or modified tests to cover relevent code **OR** my change is non-technical
- [x] Yes, I wrote this code entirely myself **OR** I properly attributed these changes in [Third Party Notices](../blob/main/THIRD-PARTY-NOTICES.txt)

<!-- After addressing the pre-requisites above, make sure to fill out BOTH sections below -->
<!-- NOTE: This is a comment; the comments below will be hidden when you submit -->

## Description of Changes
<!-- Enter a description of what this PR adds/changes -->
Modified getNext query to only include excluded IDs when they are provided

## Related Issues
<!-- Include a list and brief description of any tracked issues -->
<!-- NOTE: Make sure to use the `Closes`/`Fixes` syntax to automatically close the issue when your PR is merged -->
<!-- More detail: https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords -->
<!-- e.g., "Closes #123 - A bug that crashes the app" -->
Closes #352 