### PR TITLE
Refactoring the default config types to include values in addition to the keys

### DIFF
--- a/src/api/config.ts
+++ b/src/api/config.ts
@@ -1,7 +1,7 @@
 import express from 'express';
 import { Config } from '../entities/config';
 import logger from '../logger';
-import { defaultConfigValues } from '../types/config';
+import { DefaultConfigKeys, DefaultConfigValues, defaultConfig } from '../types/config';
 
 export const config = express.Router();
 
@@ -9,9 +9,10 @@ config.get('/', async (req, res) => {
   try {
     const configItems: Config[] = await Config.find();
 
-    for (const defaultConfigItem of defaultConfigValues) {
-      if (!configItems.find((configItem: Config) => configItem.key === defaultConfigItem)) {
-        configItems.push(new Config(defaultConfigItem, null));
+    type DefaultConfigTuples = Array<[DefaultConfigKeys, DefaultConfigValues]>;
+    for (const [key, value] of Object.entries(defaultConfig) as DefaultConfigTuples) {
+      if (!configItems.find((configItem: Config) => configItem.key === key)) {
+        configItems.push(new Config(key, value));
       }
     }
     res.send(configItems.sort((a, b) => a.key.localeCompare(b.key)));

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -1,13 +1,14 @@
 // Create an immutable array of config values
-export const defaultConfigValues = [
-  'adminSecret',
-  'jobChatQueueActive',
-  'supportRequestQueueActive',
-  'supportSecret',
-  'teamRegistrationActive',
-] as const;
+export const defaultConfig = {
+  adminSecret: null as null,
+  jobChatQueueActive: false,
+  supportRequestQueueActive: false,
+  supportSecret: null as null,
+  teamRegistrationActive: false,
+} as const;
 
-export type DefaultConfig = typeof defaultConfigValues[number];
+export type DefaultConfigKeys = keyof typeof defaultConfig;
+export type DefaultConfigValues = typeof defaultConfig[DefaultConfigKeys];
 
 export type KnownConfig =
   | 'discordBotToken'
@@ -15,4 +16,4 @@ export type KnownConfig =
   | 'slackBotToken'
   | 'slackSigningSecret'
   | 'slackNotificationsWebhookURL'
-  | DefaultConfig;
+  | DefaultConfigKeys;


### PR DESCRIPTION
## Pre-Requisites
- [x] Yes, I updated [Authors.md](../blob/main/Authors.md) **OR** this is not my first contribution
- [x] Yes, I included and/or modified tests to cover relevent code **OR** my change is non-technical
- [x] Yes, I wrote this code entirely myself **OR** I properly attributed these changes in [Third Party Notices](../blob/main/THIRD-PARTY-NOTICES.txt)

<!-- After addressing the pre-requisites above, make sure to fill out BOTH sections below -->
<!-- NOTE: This is a comment; the comments below will be hidden when you submit -->

## Description of Changes
<!-- Enter a description of what this PR adds/changes -->
Added default values for the default config items so they can be returned to the front end during setup

## Related Issues
<!-- Include a list and brief description of any tracked issues -->
<!-- NOTE: Make sure to use the `Closes`/`Fixes` syntax to automatically close the issue when your PR is merged -->
<!-- More detail: https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords -->
<!-- e.g., "Closes #123 - A bug that crashes the app" -->
Closes #297 