### PR TITLE
Config Setup Page

### DIFF
--- a/src/components/ConfigItem.tsx
+++ b/src/components/ConfigItem.tsx
@@ -29,6 +29,7 @@ export const ConfigItem: React.FC<ConfigItemProps> = ({ item, onChange }) => {
             style={{ flex: 1 }}
             className="btn btn-primary"
             onClick={(): void => {
+              // question: how does this onChange ensure that the value is updated in the database (and not just in local memory)?
               onChange({
                 key: item.key,
                 value: !item.value,

--- a/src/pages/setup.tsx
+++ b/src/pages/setup.tsx
@@ -1,0 +1,92 @@
+/* global window, fetch */
+import React from 'react';
+import { useFormik } from 'formik';
+import { config } from '../api/config';
+
+const SetupPage: React.FC = () => {
+  const formik = useFormik({
+    initialValues: {
+      secret: '',
+      adminSecret: '',
+      discordChannelIds: '',
+      discordBotToken: '',
+      slackBotToken: '',
+      slackSigningSecret: '',
+    },
+    async onSubmit(values) {
+      // TODO: Update all values in the database, and redirect to admin page
+      // QUESTION: Should I bundle the form data into multiple POST requests to the config api, or should I connect this entity directly to the database similarly to the ConfigItem?
+      // console.log(values);
+    },
+  });
+
+  return (
+    <div className="container mt-4">
+      <div className="row">
+        <div className="col-md-4 offset-md-4">
+          <h1 className="display-2 text-center">Setup</h1>
+          <h4 className="display-6 text-center">Enter your respective values for the configuration items below, then press submit.</h4>
+          <form onSubmit={formik.handleSubmit}>
+            <div className="form-group">
+              <label htmlFor="secret">adminSecret</label>
+              <input
+                id="adminSecret"
+                type="password"
+                placeholder="Shhh..."
+                className={`form-control ${formik.errors.adminSecret ? 'is-invalid' : ''}`}
+                value={formik.values.adminSecret}
+                onChange={formik.handleChange}
+                onBlur={formik.handleBlur}
+              />
+              {/* QUESTION: what is the 'htmlFor' below? Should I change these to match their respective content? */}
+              <label htmlFor="discordChannelIds">discordChannelIds</label>
+              <input
+                id="discordChannelIds"
+                placeholder="id1, id2, id3"
+                className={`form-control ${formik.errors.discordChannelIds ? 'is-invalid' : ''}`}
+                value={formik.values.discordChannelIds}
+                onChange={formik.handleChange}
+                onBlur={formik.handleBlur}
+              />
+              <label htmlFor="secret">discordBotToken</label>
+              <input
+                id="discordBotToken"
+                placeholder="enter value..."
+                className={`form-control ${formik.errors.discordBotToken ? 'is-invalid' : ''}`}
+                value={formik.values.discordBotToken}
+                onChange={formik.handleChange}
+                onBlur={formik.handleBlur}
+              />
+              <label htmlFor="secret">slackBotToken</label>
+              <input
+                id="slackBotToken"
+                placeholder="enter value..."
+                className={`form-control ${formik.errors.slackBotToken ? 'is-invalid' : ''}`}
+                value={formik.values.slackBotToken}
+                onChange={formik.handleChange}
+                onBlur={formik.handleBlur}
+              />
+              <label htmlFor="secret">slackSigningSecret</label>
+              <input
+                id="slackSigningSecret"
+                placeholder="enter value..."
+                className={`form-control ${formik.errors.slackSigningSecret ? 'is-invalid' : ''}`}
+                value={formik.values.slackSigningSecret}
+                onChange={formik.handleChange}
+                onBlur={formik.handleBlur}
+              />
+
+              {/* QUESTION: What is this below? */}
+              {/* <div className="invalid-feedback">{formik.errors.secret}</div> */}
+            </div>
+            <button type="submit" className="btn btn-dark float-right">
+              Submit
+            </button>
+          </form>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default SetupPage;


### PR DESCRIPTION
## Pre-Requisites
- [X] Yes, I updated [Authors.md](../blob/main/Authors.md) **OR** this is not my first contribution
- [] Yes, I included and/or modified tests to cover relevent code **OR** my change is non-technical
- [X] Yes, I wrote this code entirely myself **OR** I properly attributed these changes in [Third Party Notices](../blob/main/THIRD-PARTY-NOTICES.txt)

<!-- After addressing the pre-requisites above, make sure to fill out BOTH sections below -->
<!-- NOTE: This is a comment; the comments below will be hidden when you submit -->

## Description of Changes
<!-- Enter a description of what this PR adds/changes -->
Create setup page to be redirected to when configItems are not present in database (this redirect logic is being handled in #330). Add all values upon submit and restart app. 

## Related Issues
<!-- Include a list and brief description of any tracked issues -->
<!-- NOTE: Make sure to use the `Closes`/`Fixes` syntax to automatically close the issue when your PR is merged -->
<!-- More detail: https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords -->
<!-- e.g., "Closes #123 - A bug that crashes the app" -->
Closes #332 
Could close #331 if worked jointly
