### PR TITLE
added validateUser middleware to direct to login.tsx

### DIFF
--- a/src/api/middleware/requireAuth.ts
+++ b/src/api/middleware/requireAuth.ts
@@ -1,17 +1,27 @@
 import { Handler } from 'express';
 import logger from '../../logger';
 import { Config } from '../../entities/config';
+import { getActivePlatform } from '../../common/index';
 
 export const requireAuth = (redirect = false): Handler => async (req, res, next): Promise<void> => {
   const adminSecret = await Config.getValueAs('adminSecret', 'string', false);
   const supportSecret = await Config.getValueAs('supportSecret', 'string', false);
-  if (
+  const activePlatform = await getActivePlatform();
+
+  logger.info(redirect.toString());
+
+  if (!adminSecret || activePlatform === null) {
+    logger.info('Redirected user to validateUser.ts page');
+    next();
+  } else if (
     req.signedCookies?.authed === 'yes' ||
     (adminSecret && req.headers.authorization === adminSecret) ||
     (supportSecret && req.headers.authorization === supportSecret)
   ) {
+    logger.info('requireAuth passing it to next');
     next();
   } else if (redirect) {
+    logger.info('redirecting to login');
     res.redirect('/login');
   } else {
     res.sendStatus(401);

--- a/src/api/middleware/validateUser.ts
+++ b/src/api/middleware/validateUser.ts
@@ -1,0 +1,19 @@
+import { Handler } from 'express';
+import logger from '../../logger';
+import { Config } from '../../entities/config';
+import { getActivePlatform } from '../../common/index';
+
+export const validateUser = (redirect = false): Handler => async (req, res, next): Promise<void> => {
+  const activePlatform = await getActivePlatform();
+  const adminSecret = await Config.getValueAs('adminSecret', 'string', false);
+
+  logger.info(redirect.toString());
+
+  if ((!adminSecret || activePlatform === null) && redirect) {
+    logger.info('Redirected user to setup page');
+    res.redirect('/setup');
+  } else {
+    logger.info('validateUser calling next');
+    next();
+  }
+};

--- a/src/app.ts
+++ b/src/app.ts
@@ -8,6 +8,7 @@ import { PostgresConnectionOptions } from 'typeorm/driver/postgres/PostgresConne
 import { getSlackAppAndInitListeners } from './slack';
 import logger from './logger';
 import { requireAuth } from './api/middleware/requireAuth';
+import { validateUser } from './api/middleware/validateUser';
 import { getActivePlatform, SupportedPlatform } from './common';
 import { env } from './env';
 import { apiApp } from './api';
@@ -126,6 +127,7 @@ export async function initNext(): Promise<void> {
   const nextApp = next({ dev: env.nodeEnv !== 'production' });
   const nextHandler = nextApp.getRequestHandler();
   await nextApp.prepare();
+  app.get(['/'], validateUser(true), (req, res) => nextHandler(req, res));
   app.get(['/'], requireAuth(true), (req, res) => nextHandler(req, res));
   app.get('*', (req, res) => nextHandler(req, res));
 }

--- a/src/discord/events/message/registerTeam.ts
+++ b/src/discord/events/message/registerTeam.ts
@@ -25,7 +25,7 @@ interface PartialTeamInfo {
 }
 
 export async function registerTeam(msg: Discord.Message, context: DiscordContext): Promise<void> {
-  const teamRegistrationActive = await Config.findToggleForKey('teamRegistrationActive');
+  const teamRegistrationActive = await Config.getValueAs('teamRegistrationActive', 'boolean', false);
   if (!teamRegistrationActive) {
     await msg.author.send(stringDictionary.registerNotOpen);
     return;

--- a/src/discord/events/message/supportRequest.ts
+++ b/src/discord/events/message/supportRequest.ts
@@ -30,10 +30,10 @@ export async function supportRequest(msg: Discord.Message, context: DiscordConte
   let queueActive = false;
   switch (msg.content) {
     case '!jobChat':
-      queueActive = await Config.findToggleForKey('jobChatQueueActive');
+      queueActive = await Config.getValueAs('jobChatQueueActive', 'boolean', false);
       break;
     default:
-      queueActive = await Config.findToggleForKey('supportRequestQueueActive');
+      queueActive = await Config.getValueAs('supportRequestQueueActive', 'boolean', false);
       break;
   }
   if (!queueActive) {

--- a/src/pages/setup.tsx
+++ b/src/pages/setup.tsx
@@ -1,0 +1,117 @@
+/* global window, fetch */
+import React from 'react';
+import { useFormik } from 'formik';
+import { config } from '../api/config';
+
+const SetupPage: React.FC = () => {
+  const formik = useFormik({
+    initialValues: {
+      adminSecret: '',
+      discordChannelIds: '',
+      discordBotToken: '',
+      slackBotToken: '',
+      slackSigningSecret: '',
+    },
+    async onSubmit(values) {
+      // TODO: Update all values in the database, and redirect to admin page
+      // TODO: this button currently refreshes and redirects to the admin page. Razvan's redirect changes should cover this to redirect to login
+      const res = await fetch('/api/config/bulk', {
+        method: 'POST',
+        body: JSON.stringify({
+          configKeys: [
+            'adminSecret',
+            'discordChannelIds',
+            'discordBotToken',
+            'slackBotToken',
+            'slackSigningSecret',
+          ],
+          configValues: [
+            values.adminSecret,
+            values.discordChannelIds,
+            values.discordBotToken,
+            values.slackBotToken,
+            values.slackSigningSecret,
+          ],
+        }),
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      });
+
+      if (res.ok) {
+        // eslint-disable-next-line no-console
+        console.log(res);
+      }
+      // window.location.href = '/';
+    },
+  });
+
+  return (
+    <div className="container mt-4">
+      <div className="row">
+        <div className="col-md-4 offset-md-4">
+          <h1 className="display-2 text-center">Setup</h1>
+          <h4 className="display-6 text-center">Enter your respective values for the configuration items below, then press submit.</h4>
+          <form onSubmit={formik.handleSubmit}>
+            <div className="form-group">
+              <label htmlFor="secret">adminSecret</label>
+              <input
+                id="adminSecret"
+                type="password"
+                placeholder="Shhh..."
+                className={`form-control ${formik.errors.adminSecret ? 'is-invalid' : ''}`}
+                value={formik.values.adminSecret}
+                onChange={formik.handleChange}
+                onBlur={formik.handleBlur}
+              />
+              {/* QUESTION: what is the 'htmlFor' below? Should I change these to match their respective content? */}
+              <label htmlFor="discordChannelIds">discordChannelIds</label>
+              <input
+                id="discordChannelIds"
+                placeholder="id1, id2, id3"
+                className={`form-control ${formik.errors.discordChannelIds ? 'is-invalid' : ''}`}
+                value={formik.values.discordChannelIds}
+                onChange={formik.handleChange}
+                onBlur={formik.handleBlur}
+              />
+              <label htmlFor="secret">discordBotToken</label>
+              <input
+                id="discordBotToken"
+                placeholder="enter value..."
+                className={`form-control ${formik.errors.discordBotToken ? 'is-invalid' : ''}`}
+                value={formik.values.discordBotToken}
+                onChange={formik.handleChange}
+                onBlur={formik.handleBlur}
+              />
+              <label htmlFor="secret">slackBotToken</label>
+              <input
+                id="slackBotToken"
+                placeholder="enter value..."
+                className={`form-control ${formik.errors.slackBotToken ? 'is-invalid' : ''}`}
+                value={formik.values.slackBotToken}
+                onChange={formik.handleChange}
+                onBlur={formik.handleBlur}
+              />
+              <label htmlFor="secret">slackSigningSecret</label>
+              <input
+                id="slackSigningSecret"
+                placeholder="enter value..."
+                className={`form-control ${formik.errors.slackSigningSecret ? 'is-invalid' : ''}`}
+                value={formik.values.slackSigningSecret}
+                onChange={formik.handleChange}
+                onBlur={formik.handleBlur}
+              />
+              {/* QUESTION: What is this below? */}
+              {/* <div className="invalid-feedback">{formik.errors.adminSecret}</div> */}
+            </div>
+            <button type="submit" className="btn btn-dark float-right">
+              Submit
+            </button>
+          </form>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default SetupPage;


### PR DESCRIPTION
## Pre-Requisites
- [x] Yes, I updated [Authors.md](../blob/main/Authors.md) **OR** this is not my first contribution
- [ ] Yes, I included and/or modified tests to cover relevent code **OR** my change is non-technical
- [x] Yes, I wrote this code entirely myself **OR** I properly attributed these changes in [Third Party Notices](../blob/main/THIRD-PARTY-NOTICES.txt)

<!-- After addressing the pre-requisites above, make sure to fill out BOTH sections below -->
<!-- NOTE: This is a comment; the comments below will be hidden when you submit -->

## Description of Changes
<!-- Enter a description of what this PR adds/changes -->
Adds middleware to handle user startup without having slack/discord or adminSecret setup.

## Related Issues
<!-- Include a list and brief description of any tracked issues -->
<!-- NOTE: Make sure to use the `Closes`/`Fixes` syntax to automatically close the issue when your PR is merged -->
<!-- More detail: https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords -->
<!-- e.g., "Closes #123 - A bug that crashes the app" -->
Closes #330 - Allow user to start app without slack/discord setup or adminSecret