### PR TITLE
Add isAdmin to user and fix safe json method

### DIFF
--- a/packages/api/.eslintrc
+++ b/packages/api/.eslintrc
@@ -52,6 +52,12 @@
         "global-require": "off",
         "import/no-extraneous-dependencies": "off"
       }
+    },
+    {
+      "files": ["**/entities/*.ts"],
+      "rules": {
+        "class-methods-use-this": ["error", { "exceptMethods": ["getSafeKeys"] }]
+      }
     }
   ]
 }

--- a/packages/api/src/@types/index.d.ts
+++ b/packages/api/src/@types/index.d.ts
@@ -8,9 +8,15 @@ declare global {
       entityManager: EntityManager<PostgreSqlDriver>;
       /**
        * This will ONLY be defined if you have the `populateUser`
-       * middleware used before this handler
+       * middleware used before this handler. If you are unsure
+       * if it will exist, use `safeUserEntity` instead.
        */
       userEntity: UserEntity;
+      /**
+       * This will be setup with the `populateUser` middleware.
+       * Use this property if you are unsure if it's been called or not.
+       */
+       safeUserEntity?: UserEntity;
     }
     export interface User {
       accessToken: string;

--- a/packages/api/src/@types/index.d.ts
+++ b/packages/api/src/@types/index.d.ts
@@ -16,7 +16,7 @@ declare global {
        * This will be setup with the `populateUser` middleware.
        * Use this property if you are unsure if it's been called or not.
        */
-       safeUserEntity?: UserEntity;
+      safeUserEntity?: UserEntity;
     }
     export interface User {
       accessToken: string;

--- a/packages/api/src/api/subscription.ts
+++ b/packages/api/src/api/subscription.ts
@@ -3,7 +3,7 @@ import logger from '../logger';
 import { populateUser } from '../middleware/populateUser';
 
 export const subscription = Router();
-subscription.use(populateUser);
+subscription.use(populateUser());
 
 const subscriptionHandler =
   (subscribe: boolean): Handler =>

--- a/packages/api/src/api/users.ts
+++ b/packages/api/src/api/users.ts
@@ -1,8 +1,10 @@
 import { Router } from 'express';
 import { User } from '../entities/User';
+import { populateUser } from '../middleware/populateUser';
 import logger from '../logger';
 
 export const users = Router();
+users.use(populateUser());
 
 users.get('/:userId', async (req, res) => {
   const { userId } = req.params;
@@ -22,7 +24,7 @@ users.get('/:userId', async (req, res) => {
       return;
     }
 
-    res.status(200).send(user);
+    res.send(user.toSafeJSON(req));
   } catch (error) {
     logger.error(`There was an issue getting user "${userId}"`, error);
     res.status(500).send('There was an issue getting user');

--- a/packages/api/src/entities/Event.ts
+++ b/packages/api/src/entities/Event.ts
@@ -8,8 +8,6 @@ type EventPropertyKeys = keyof EventConstructorValues;
 
 @Entity()
 export class Event extends Node<Event> {
-  SAFE_KEYS: EventPropertyKeys[] = ['name', 'start', 'end', 'description'];
-
   @Property({ columnType: 'text' })
   name: string;
 
@@ -29,5 +27,9 @@ export class Event extends Node<Event> {
     this.start = start;
     this.end = end;
     this.description = description;
+  }
+
+  getSafeKeys(): EventPropertyKeys[] {
+    return ['name', 'start', 'end', 'description'];
   }
 }

--- a/packages/api/src/entities/Node.ts
+++ b/packages/api/src/entities/Node.ts
@@ -13,8 +13,6 @@ const isReference = (val: any): val is IdentifiedReference<AnyNode> =>
   typeof val === 'object' && val && 'isInitialized' in val;
 
 export abstract class Node<T extends AnyEntity> extends BaseEntity<T, 'id'> {
-  abstract SAFE_KEYS: Array<keyof T>;
-
   @PrimaryKey({ type: BigIntType })
   public id!: string;
 
@@ -35,7 +33,9 @@ export abstract class Node<T extends AnyEntity> extends BaseEntity<T, 'id'> {
     }
   }
 
-  toSafeJSON() {
+  abstract getSafeKeys(req: Express.Request): Array<keyof T>;
+
+  toSafeJSON(req: Express.Request) {
     const json = this.toJSON();
 
     for (const [key, val] of Object.entries(this) as Array<
@@ -47,9 +47,10 @@ export abstract class Node<T extends AnyEntity> extends BaseEntity<T, 'id'> {
     }
 
     const safeJson: Record<string, any> = {};
+    const safeKeys = ['id', 'createdAt', 'updatedAt', ...this.getSafeKeys(req)];
 
     for (const [key, val] of Object.entries(json)) {
-      if (this.SAFE_KEYS.includes(key)) {
+      if (safeKeys.includes(key)) {
         safeJson[key] = val;
       }
     }

--- a/packages/api/src/entities/Prize.ts
+++ b/packages/api/src/entities/Prize.ts
@@ -8,8 +8,6 @@ type PrizePropertyKeys = keyof PrizeConstructorValues;
 
 @Entity()
 export class Prize extends Node<Prize> {
-  SAFE_KEYS: PrizePropertyKeys[] = ['name', 'description', 'isBonus'];
-
   @Property({ columnType: 'text' })
   name: string;
 
@@ -27,5 +25,9 @@ export class Prize extends Node<Prize> {
 
     this.name = name;
     this.sortOrder = sortOrder;
+  }
+
+  getSafeKeys(): PrizePropertyKeys[] {
+    return ['name', 'description', 'isBonus'];
   }
 }

--- a/packages/api/src/entities/QueueUser.ts
+++ b/packages/api/src/entities/QueueUser.ts
@@ -22,8 +22,6 @@ export enum QueueStatus {
 
 @Entity()
 export class QueueUser extends Node<QueueUser> {
-  SAFE_KEYS: QueueUserPropertyKeys[] = ['user', 'type', 'status'];
-
   @ManyToOne(() => User)
   user: IdentifiedReference<User>;
 
@@ -38,5 +36,9 @@ export class QueueUser extends Node<QueueUser> {
 
     this.user = user;
     this.type = type;
+  }
+
+  getSafeKeys(): QueueUserPropertyKeys[] {
+    return ['user', 'type', 'status'];
   }
 }

--- a/packages/api/src/middleware/populateUser.ts
+++ b/packages/api/src/middleware/populateUser.ts
@@ -2,22 +2,34 @@ import { Handler } from 'express';
 import { User } from '../entities/User';
 import logger from '../logger';
 
-export const populateUser: Handler = async (req, res, next) => {
-  try {
-    const user = await req.entityManager.fork().findOne(User, { authId: req.user?.profile.id });
+interface PopulateUserOptions {
+  adminOnly?: boolean;
+}
 
-    if (!user) {
-      res.sendStatus(401);
-      logger.error('Unable to find user for request: ', req);
-      return;
+export const populateUser =
+  (opts?: PopulateUserOptions): Handler =>
+  async (req, res, next) => {
+    try {
+      const user = await req.entityManager.fork().findOne(User, { authId: req.user?.profile.id });
+
+      if (!user) {
+        res.sendStatus(401);
+        logger.error('Unable to find user for request: ', req);
+        return;
+      }
+
+      if (opts?.adminOnly && !user.isAdmin) {
+        res.sendStatus(403);
+        return;
+      }
+
+      req.userEntity = user;
+      req.safeUserEntity = user;
+
+      next();
+    } catch (err) {
+      const errorText = 'Server error occurred while validating user';
+      res.status(500).send(errorText);
+      logger.error(errorText, err);
     }
-
-    req.userEntity = user;
-
-    next();
-  } catch (err) {
-    const errorText = 'Server error occurred while validating user';
-    res.status(500).send(errorText);
-    logger.error(errorText, err);
-  }
-};
+  };

--- a/packages/api/src/migrations/0006-add-isadmin-to-user.ts
+++ b/packages/api/src/migrations/0006-add-isadmin-to-user.ts
@@ -1,0 +1,11 @@
+import { Migration } from '@mikro-orm/migrations';
+
+export class Migration20211104184422 extends Migration {
+  async up(): Promise<void> {
+    this.addSql('alter table "user" add column "isAdmin" bool not null default false;');
+  }
+
+  async down(): Promise<void> {
+    this.addSql('alter table "user" drop column "isAdmin";');
+  }
+}

--- a/packages/api/src/utils/types.ts
+++ b/packages/api/src/utils/types.ts
@@ -12,7 +12,4 @@ export type ConstructorValues<
   Entity extends AnyNode,
   RemovedKeys extends keyof OmitMethods<Omit<Entity, keyof Node<Entity>>> = never,
   OptionalKeys extends keyof OmitMethods<Omit<Entity, keyof Node<Entity> | RemovedKeys>> = never,
-> = SetOptional<
-  OmitMethods<Omit<Entity, keyof Node<Entity> | RemovedKeys | 'SAFE_KEYS'>>,
-  OptionalKeys
->;
+> = SetOptional<OmitMethods<Omit<Entity, keyof Node<Entity> | RemovedKeys>>, OptionalKeys>;

--- a/packages/api/tests/api/subscription.test.ts
+++ b/packages/api/tests/api/subscription.test.ts
@@ -1,18 +1,20 @@
+import { Handler } from 'express';
 import { subscription } from '../../src/api/subscription';
 import { User } from '../../src/entities/User';
 import logger from '../../src/logger';
-import { populateUser } from '../../src/middleware/populateUser';
-import { getMock } from '../testUtils/getMock';
 import { testHandler } from '../testUtils/testHandler';
 
 const loggerSpy = jest.spyOn(logger, 'error').mockImplementation();
-jest.mock('../../src/middleware/populateUser.ts');
-const mockUser = {} as User;
+const mockUser = { id: 'mocked' } as User;
 
-const populateUserMock = getMock(populateUser).mockImplementation((req, res, next) => {
-  req.userEntity = mockUser as User;
-  next();
-});
+jest.mock('../../src/middleware/populateUser.ts', () => ({
+  populateUser: jest.fn(
+    (): Handler => (req, _res, next) => {
+      req.userEntity = mockUser as User;
+      next();
+    },
+  ),
+}));
 
 describe('/subscriptions', () => {
   beforeEach(async () => {

--- a/packages/api/tests/entities/Node.test.ts
+++ b/packages/api/tests/entities/Node.test.ts
@@ -1,8 +1,6 @@
 import { Node } from '../../src/entities/Node';
 
 class TestNode extends Node<TestNode> {
-  SAFE_KEYS: (keyof TestNode)[] = ['field', 'reference'];
-
   field?: string;
 
   sensitive?: string;
@@ -10,6 +8,10 @@ class TestNode extends Node<TestNode> {
   reference?: { id: string; isInitialized: () => boolean };
 
   sensitiveReference?: { id: string; isInitialized: () => boolean };
+
+  getSafeKeys(): (keyof TestNode)[] {
+    return ['field', 'reference'];
+  }
 
   toJSON() {
     return {
@@ -33,7 +35,9 @@ describe('Node', () => {
   });
 
   it('toSafeJson changes initialized references to be just the id and removes keys not in SAFE_KEYS', () => {
-    expect(new TestNode({ field, reference, sensitive, sensitiveReference }).toSafeJSON()).toEqual({
+    expect(
+      new TestNode({ field, reference, sensitive, sensitiveReference }).toSafeJSON({} as any),
+    ).toEqual({
       field,
       reference: { id: reference.id },
     });

--- a/packages/api/tsconfig.build.json
+++ b/packages/api/tsconfig.build.json
@@ -3,5 +3,5 @@
   "compilerOptions": {
     "noEmit": false
   },
-  "exclude": ["node_modules", "tests/**/*"]
+  "exclude": ["node_modules", "tests/**/*", "src/__mocks__"]
 }


### PR DESCRIPTION
### Pre-Requisites
<!-- Replace the [ ] with [x] (lowercase x) to check the box -->
- [x] Yes, I updated [Authors.md](../blob/main/Authors.md) **OR** this is not my first contribution
- [x] Yes, I included and/or modified tests to cover relevant code **OR** my change is non-technical
- [x] Yes, I wrote this code entirely myself **OR** I properly attributed these changes in [Third Party Notices](../blob/main/THIRD-PARTY-NOTICES.txt)

<!-- After addressing the pre-requisites above, make sure to fill out BOTH sections below -->
<!-- NOTE: This is a comment; the comments below will be hidden when you submit -->

## Description of Changes
<!-- Enter a description of what this PR adds/changes -->
- Added `isAdmin` to the `User` entity (with migration)
- Fixed a bug with the `toSafeJSON` method
- Added an options object to `populateUser` that allows you to only allow admins past that point

## Related Issues
<!-- Include a list and brief description of any tracked issues -->
<!-- NOTE: Make sure to use the `Closes`/`Fixes` syntax to automatically close the issue when your PR is merged -->
<!-- More detail: https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords -->
<!-- e.g., "Closes #123 - A bug that crashes the app" -->
Closes #398 