### PR TITLE
Allow safe json to not remove references

### DIFF
--- a/packages/api/tests/entities/Node.test.ts
+++ b/packages/api/tests/entities/Node.test.ts
@@ -5,7 +5,12 @@ class TestNode extends Node<TestNode> {
 
   sensitive?: string;
 
-  reference?: { id: string; isInitialized: () => boolean };
+  reference?: {
+    id: string;
+    isInitialized: () => boolean;
+    getEntity: () => any;
+    toSafeJSON: () => any;
+  };
 
   sensitiveReference?: { id: string; isInitialized: () => boolean };
 
@@ -25,7 +30,14 @@ class TestNode extends Node<TestNode> {
 
 const field = 'hello';
 const sensitive = 'password123';
-const reference = { id: 'user123', otherKey: 'wow', isInitialized: () => true };
+const mockedToSafeJSONReference = { id: 'safe-ref' };
+const reference = {
+  id: 'user123',
+  otherKey: 'wow',
+  isInitialized: () => true,
+  getEntity: () => reference,
+  toSafeJSON: jest.fn(() => mockedToSafeJSONReference),
+};
 const sensitiveReference = { id: 'admin123', otherKey: 'wow', isInitialized: () => true };
 
 describe('Node', () => {
@@ -41,5 +53,17 @@ describe('Node', () => {
       field,
       reference: { id: reference.id },
     });
+  });
+
+  it('toSafeJson with removeReferences set to false calls toSafeJSON on the entity', () => {
+    const mockReq = { mockReq: 'mock' } as any;
+    expect(
+      new TestNode({ field, reference, sensitive, sensitiveReference }).toSafeJSON(mockReq, false),
+    ).toEqual({
+      field,
+      reference: mockedToSafeJSONReference,
+    });
+
+    expect(reference.toSafeJSON).toHaveBeenCalledWith(mockReq, false);
   });
 });


### PR DESCRIPTION
### Pre-Requisites
<!-- Replace the [ ] with [x] (lowercase x) to check the box -->
- [x] Yes, I updated [Authors.md](../blob/main/Authors.md) **OR** this is not my first contribution
- [x] Yes, I included and/or modified tests to cover relevant code **OR** my change is non-technical
- [x] Yes, I wrote this code entirely myself **OR** I properly attributed these changes in [Third Party Notices](../blob/main/THIRD-PARTY-NOTICES.txt)

<!-- After addressing the pre-requisites above, make sure to fill out BOTH sections below -->
<!-- NOTE: This is a comment; the comments below will be hidden when you submit -->

## Description of Changes
<!-- Enter a description of what this PR adds/changes -->
Now you can pass `false` as the second param for `toSafeJSON` to not unpopulate references

## Related Issues
<!-- Include a list and brief description of any tracked issues -->
<!-- NOTE: Make sure to use the `Closes`/`Fixes` syntax to automatically close the issue when your PR is merged -->
<!-- More detail: https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords -->
<!-- e.g., "Closes #123 - A bug that crashes the app" -->
