### PR TITLE
edit queue status endpoint

### DIFF
--- a/packages/api/src/api/queue.ts
+++ b/packages/api/src/api/queue.ts
@@ -1,7 +1,8 @@
 import { Router } from 'express';
 import logger from '../logger';
-import { QueueUser, QueueType } from '../entities/QueueUser';
+import { QueueUser, QueueType, QueueStatus } from '../entities/QueueUser';
 import { populateUser } from '../middleware/populateUser';
+import { messageUsers } from './discord';
 
 export const queue = Router();
 queue.use(populateUser());
@@ -63,6 +64,40 @@ queue.post('/', async (req, res) => {
     res.send(200);
   } catch (err) {
     const errorMsg = 'There was an issue adding a user to a queue';
+    logger.error(`${errorMsg}: `, err);
+    res.status(500).send(errorMsg);
+  }
+});
+
+queue.put('/:id', async (req, res) => {
+  const user = req.userEntity;
+  const { id } = req.params;
+  const { status } = req.body;
+  if (!user.isAdmin) {
+    res.sendStatus(403);
+    return;
+  }
+
+  try {
+    const queueItemToChange = await req.entityManager.findOne(QueueUser, { id });
+
+    if (!queueItemToChange) {
+      res.sendStatus(404);
+      return;
+    }
+
+    if (queueItemToChange.status === QueueStatus.Pending && status === QueueStatus.InProgress) {
+      queueItemToChange.assignee = user.toReference();
+      const message = `${user.name} is ready to assist you! Please make your way to the American Airlines booth and ask to see ${user.name}.`;
+      messageUsers(queueItemToChange.user.id, message);
+    }
+
+    queueItemToChange.status = status;
+
+    await req.entityManager.flush();
+    res.sendStatus(200);
+  } catch (err) {
+    const errorMsg = 'There was an issue popping a user off of the queue';
     logger.error(`${errorMsg}: `, err);
     res.status(500).send(errorMsg);
   }

--- a/packages/api/src/api/queue.ts
+++ b/packages/api/src/api/queue.ts
@@ -89,7 +89,7 @@ queue.put('/:id', async (req, res) => {
     if (queueItemToChange.status === QueueStatus.Pending && status === QueueStatus.InProgress) {
       queueItemToChange.assignee = user.toReference();
       const message = `${user.name} is ready to assist you! Please make your way to the American Airlines booth and ask to see ${user.name}.`;
-      messageUsers(queueItemToChange.user.id, message);
+      await messageUsers(queueItemToChange.user.id, message);
     }
 
     queueItemToChange.status = status;


### PR DESCRIPTION
## Pre-Requisites
- [x] Yes, I updated [Authors.md](../blob/main/Authors.md) **OR** this is not my first contribution
- [x] Yes, I included and/or modified tests to cover relevent code **OR** my change is non-technical
- [x] Yes, I wrote this code entirely myself **OR** I properly attributed these changes in [Third Party Notices](../blob/main/THIRD-PARTY-NOTICES.txt)

<!-- After addressing the pre-requisites above, make sure to fill out BOTH sections below -->
<!-- NOTE: This is a comment; the comments below will be hidden when you submit -->

## Description of Changes
<!-- Enter a description of what this PR adds/changes -->
Given a specific queue item id as well as a queue item status, will change the queue item to the new status. If the status goes from `pending` to `in progress`, an `assignee` will be given to the queue item and a discord message will be sent to the use associated with the queue item.

## Related Issues
<!-- Include a list and brief description of any tracked issues -->
<!-- NOTE: Make sure to use the `Closes`/`Fixes` syntax to automatically close the issue when your PR is merged -->
<!-- More detail: https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords -->
<!-- e.g., "Closes #123 - A bug that crashes the app" -->
Don't think there's an open issue for this