### PR TITLE
fix: triggering build action on v3 merge, adding missing codecov link to README

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,8 @@
 name: Build
 
 on:
+  push:
+    branches: [main, v3]
   pull_request:
     branches: [main, v3]
   merge_group:

--- a/README.md
+++ b/README.md
@@ -5,7 +5,9 @@
   <img src="https://img.shields.io/badge/Author-%40AmericanAirlines-blue" />
   <img src="https://img.shields.io/badge/Version-v3-%5B0%2C0%2C255%5D" />
   <img src="https://github.com/AmericanAirlines/Hangar/actions/workflows/build.yml/badge.svg?branch=v3" />
-  <img src="https://codecov.io/github/AmericanAirlines/Hangar/branch/v3/graph/badge.svg" />
+  <a href="https://app.codecov.io/gh/AmericanAirlines/Hangar/tree/v3">
+    <img src="https://codecov.io/github/AmericanAirlines/Hangar/branch/v3/graph/badge.svg" />
+  </a>
   <a href="https://opensource.org/licenses/MIT">
     <img src="https://img.shields.io/badge/License-MIT-blue.svg" aria-title="License: MIT" />
   </a>


### PR DESCRIPTION
## Pre-Requisites
- [x] Yes, I updated [Authors.md](../blob/main/Authors.md) **OR** this is not my first contribution
- [x] Yes, I included and/or modified tests to cover relevent code **OR** my change is non-technical
- [x] Yes, I wrote this code entirely myself **OR** I properly attributed these changes in [Third Party Notices](../blob/main/THIRD-PARTY-NOTICES.txt)

<!-- After addressing the pre-requisites above, make sure to fill out BOTH sections below -->
<!-- NOTE: This is a comment; the comments below will be hidden when you submit -->

## Description of Changes
<!-- Enter a description of what this PR adds/changes -->

## Related Issues
<!-- Include a list and brief description of any tracked issues -->
<!-- NOTE: Make sure to use the `Closes`/`Fixes` syntax to automatically close the issue when your PR is merged -->
<!-- More detail: https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords -->
<!-- e.g., "Closes #123 - A bug that crashes the app" -->
