### PR TITLE
bugfix: fixing duplicate project location error handling

### DIFF
--- a/packages/api/src/api/project/post.ts
+++ b/packages/api/src/api/project/post.ts
@@ -51,6 +51,11 @@ export const post = async (req: Request, res: Response) => {
       res.sendStatus(423);
       return;
     }
+    if ((error as DriverException).code === '23505') {
+      // Duplicate key error
+      res.status(400).send('Project with that location already exists');
+      return;
+    }
     // All other errors
     logger.error(error);
     res.sendStatus(500);

--- a/packages/api/tests/api/project/post.test.ts
+++ b/packages/api/tests/api/project/post.test.ts
@@ -129,4 +129,20 @@ describe('project post endpoint', () => {
 
     expect(req.entityManager.transactional).not.toBeCalled();
   });
+
+  it('returns a 400 when there is a duplicate constraint violation', async () => {
+    const data = { name: 'A cool project' };
+    validatePayloadMock.mockReturnValueOnce({ errorHandled: false, data } as any);
+    const req = createMockRequest({ user: { id: '1' } as any });
+    const res = createMockResponse();
+    (axios.get as jest.Mock).mockResolvedValueOnce({ status: 200 });
+    req.entityManager.findOneOrFail.mockRejectedValueOnce({ code: '23505' }); // Unique constraint violation
+
+    await post(req as any, res as any);
+
+    expect(req.entityManager.transactional).toBeCalledTimes(1);
+    expect(req.entityManager.persist).not.toBeCalled();
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.send).toHaveBeenLastCalledWith('Project with that location already exists');
+  });
 });

--- a/packages/database/src/entitiesUtils/Judge/getNextProject.ts
+++ b/packages/database/src/entitiesUtils/Judge/getNextProject.ts
@@ -36,7 +36,7 @@ export const getNextProject = async ({
       entityManager.find(
         Project,
         { id: { $nin: excludedProjectIds, $in: projectsFromSession.getIdentifiers() } }, // Don't visit projects the judge has already visited or skipped
-        { fields: ['id', 'activeJudgeCount'], populateWhere: {} }, // Only pull the fields we need
+        { fields: ['id', 'activeJudgeCount'] }, // Only pull the fields we need
       ),
     ),
     // Fetch all relevant votes to figure out which teams have been visited the most

--- a/packages/shared/src/schema/project/core.ts
+++ b/packages/shared/src/schema/project/core.ts
@@ -15,7 +15,12 @@ export const core = z.object({
     .trim()
     .min(validation.MIN_DESCRIPTION_LENGTH)
     .max(validation.MAX_DESCRIPTION_LENGTH),
-  location: z.string().trim().max(validation.MAX_LOCATION_LENGTH).optional(),
+  location: z
+    .string()
+    .trim()
+    .max(validation.MAX_LOCATION_LENGTH)
+    .transform((data) => (data !== '' ? data : undefined)) // Make sure an empty string is always coerced to undefined
+    .optional(),
   repoUrl: z
     .string()
     .trim()

--- a/packages/shared/tests/schema/project/core.test.ts
+++ b/packages/shared/tests/schema/project/core.test.ts
@@ -23,8 +23,8 @@ describe('project put schema', () => {
   it('trims relevant fields', () => {
     const project = {
       ...validProject,
-      location: 'somewhere',
-      name: 'someone',
+      location: ' somewhere ',
+      name: ' someone ',
       description: ' something something dark side ',
     };
     const result = Schema.project.core.safeParse(project);

--- a/packages/shared/tests/schema/project/core.test.ts
+++ b/packages/shared/tests/schema/project/core.test.ts
@@ -20,12 +20,12 @@ describe('project put schema', () => {
     expect(Schema.project.core.safeParse(projectWithoutLocation).success).toBe(true);
   });
 
-  it('trims relevant field', () => {
+  it('trims relevant fields', () => {
     const project = {
       ...validProject,
       location: 'somewhere',
       name: 'someone',
-      description: 'something something dark side',
+      description: ' something something dark side ',
     };
     const result = Schema.project.core.safeParse(project);
 
@@ -85,5 +85,24 @@ describe('project put schema', () => {
         repoUrl: 'https://google.com',
       }).success,
     ).toBe(false);
+  });
+
+  it('coerces empty location strings to undefined', () => {
+    const result = Schema.project.core.safeParse({
+      ...validProject,
+      location: ' ',
+    });
+
+    if (!result.success) throw new Error(result.error.toString());
+
+    expect(result.data.location).toBeUndefined();
+  });
+
+  it('correctly validates location strings', () => {
+    const result = Schema.project.core.safeParse(validProject);
+
+    if (!result.success) throw new Error(result.error.toString());
+
+    expect(result.data.location).toBe(validProject.location);
   });
 });


### PR DESCRIPTION
### Description of Changes
👆 

- Removed an unused argument to a mikro-orm method

### Related Issues
<!-- Make sure to use the `Closes`/`Fixes` syntax to automatically close the issue when your PR is merged -->
<!-- e.g., "Closes #123 - A bug that crashes the app" -->
